### PR TITLE
Include docs missed from prior PRs

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,80 +1,133 @@
+
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to make participation in our project and
-our community a harassment-free experience for everyone, regardless of age,
-body size, disability, ethnicity, sex characteristics, gender identity and
-expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behaviors that contribute to creating a positive environment
-include:
+Examples of behavior that contributes to a positive environment for our
+community include:
 
-- Using welcoming and inclusive language
-- Being respectful of differing viewpoints and experiences
-- Gracefully accepting constructive criticism
-- Focusing on what is best for the community
-- Showing empathy towards other community members
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behavior include:
 
-- The use of sexualized language or imagery and unwelcome sexual attention
-or advances
-- Trolling, insulting/derogatory comments, and personal or political attacks
-- Public or private harassment
-- Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-- Other conduct which could reasonably be considered inappropriate in a
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
-## Our Responsibilities
+## Enforcement Responsibilities
 
-Project maintainers are responsible for clarifying the standards of
-acceptable behavior and are expected to take appropriate and fair
-corrective action in response to any instances of unacceptable behavior.
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem
-inappropriate, threatening, offensive, or harmful.
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies within all project spaces--including the Discord
-server and other aligned forums--and also applies when an individual is
-representing the project or its community in public spaces. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an
-appointed representative at an online or offline event. Representation of this
-project may further be defined and clarified by project maintainers.
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at nonsensetwice@gmail.com. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an
-incident. Further details of specific enforcement policies may be posted
-separately.
+reported to the community leaders responsible for enforcement at
+nonsensetwice@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
 
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 1.4, available at
-<https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
 
 [homepage]: https://www.contributor-covenant.org
-
-For answers to common questions about this code of conduct, see
-<https://www.contributor-covenant.org/faq>
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,80 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age,
+body size, disability, ethnicity, sex characteristics, gender identity and
+expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behaviors that contribute to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention
+or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of
+acceptable behavior and are expected to take appropriate and fair
+corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem
+inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces--including the Discord
+server and other aligned forums--and also applies when an individual is
+representing the project or its community in public spaces. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event. Representation of this
+project may further be defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at nonsensetwice@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an
+incident. Further details of specific enforcement policies may be posted
+separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+<https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+<https://www.contributor-covenant.org/faq>

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contribution Guidelines
+
+This project utilizes a [Trunk-based development](https://trunkbaseddevelopment.com) approach, emphasizing the use of forks.
+
+## To begin working on an issue
+
+1. Fork the repository
+2. Create a feature branch that branches off of `main`
+3. Maintain open discussion regarding the issue you are working on
+4. Keep your fork's main branch in sync with the upstream main branch; keep
+your development branch updated with the latest changes as well
+5. Document everything
+
+## Submitting a PR
+
+Before you submit your Pull Request (PR):
+
+1. Pull the latest changes from the upstream `main` branch into your feature
+branch and resolve any merge conflicts
+2. Update the `CHANGELOG.md` to include a short description of your changes in
+the next version
+3. Run linting scripts and fix any issues that arise
+4. Double check that your documentation is complete
+5. In GitHub, open a pull request to merge your development branch from your
+fork into the upstream repo's `main`

--- a/.github/WORKFLOW.md
+++ b/.github/WORKFLOW.md
@@ -1,5 +1,5 @@
 # Workflow
-This is extended from [CONTRIBUTING.md](https://github.com/nonsensetwice/gauntlet/blob/main/docs). Please read that document before perusing this one, as it provides a general overview of the trunk-based workflow in use.
+This is extended from [CONTRIBUTING.md](https://github.com/nonsensetwice/gauntlet/blob/main/.github/CONTRIBUTING.md). Please read that document before perusing this one, as it provides a general overview of the trunk-based workflow in use.
 
 # Git Branches
 

--- a/.github/WORKFLOW.md
+++ b/.github/WORKFLOW.md
@@ -1,0 +1,62 @@
+# Workflow
+This is extended from [CONTRIBUTING.md](https://github.com/nonsensetwice/gauntlet/blob/main/docs). Please read that document before perusing this one, as it provides a general overview of the trunk-based workflow in use.
+
+# Git Branches
+
+These is one major branch:
+
+1. main
+
+-   is protected
+-   requires PR approval before merge
+-   contains production ready code
+-   code that users are using
+-   possible impact if something is wrong
+-   any new commit triggers auto deployment
+
+There are a number of naming conventions for development branches you'll work
+on in your fork:
+
+1. [username]/feature/[feature-name]
+
+-   new feature based on issue or request
+-   this branch is created from `main` branch
+-   can be deleted
+
+4. [username]/patch/[feature]
+
+-   used to patch new features that almost ready to PR or whose PR has been
+    closed due to a number of fixes that need to be implemented
+
+5. hotfix/x.x.x
+
+-   in case a bug is found in production this is forked from main
+-   very small changes
+-   should be merged quickly once approval is done
+
+## Contributor Workflow
+
+### Fork repository
+
+### Create feature branch from main
+
+### Create PR from my-username/feature/my-new-feature -> main
+
+-   PR is reviewed,
+-   review confirms it works, follows contribution conventions, looks good
+-   developer test PR in local computer, their discord guild
+-   CI/CD will validate that all test cases are good
+-   PR reviewers test cases are created
+-   CI/CD validate test and code is code
+-   deploy to test linux/ubuntu server
+-   deploy to shared test guild
+-   CI/CD integration validation
+
+### PR merged to main
+
+-   production release
+-   have a call with devs to ensure everything runs smoothly
+
+https://trunkbaseddevelopment.com
+
+And remember to Document, Document, Document!

--- a/README.md
+++ b/README.md
@@ -44,8 +44,11 @@ First off, read the docs, as outlined below. Second, review the issues. Third, [
   
 TypeScript and JavaScript developers are all welcome to pop in and help as we progress through reorganization. If you're new to open source contribution, or development generally, feel free to pair up with someone or get a small team together to tackle issues.
 
-Please read the [contributor docs](https://github.com/nonsensetwice/gauntlet/blob/main/docs) and [code of conduct](https://github.com/nonsensetwice/gauntlet/blob/main/docs/CODE_OF_CONDUCT.md) before diving in.
+Please read the contributor docs, [CONTRIBUTING.md][contributing] & [WORKFLOW.md][workflow], and [code of conduct](https://github.com/nonsensetwice/gauntlet/blob/main/.github/CODE_OF_CONDUCT.md) before diving in.
 
 If you have questions about how to get started, reach out to me on Discord via the server linked above, or on [twitter](https://twitter.com/nonsensecodes).
 
 The current state of this project leaves much work to be done to bring it to a point of ease of contribution, so if you're ready to get your hands dirty with some cleanup, pick up an issue and LFG🚀! 
+  
+[contributing]: https://github.com/nonsensetwice/gauntlet/blob/main/.github/CONTRIBUTING.md
+[workflow]: https://github.com/nonsensetwice/gauntlet/blob/main/.github/WORKFLOW.md


### PR DESCRIPTION
patch hacktoberfest setup, include documentation for real this time

`.gitignore` included `docs/` directory, causing contributor documentation delivery to fail. Documentation has since been moved to `/.github` and references updated.